### PR TITLE
Update to current msgpack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "dependencies": {
     "underscore": "~1.7.0",
     "natural": "~0.1.28",
-    "msgpack": "~0.2.4"
+    "msgpack": "~1.0.2"
   }
 }

--- a/scripts/quote.js
+++ b/scripts/quote.js
@@ -4,7 +4,7 @@
 // Dependencies:
 //   underscore: ~1.7.0
 //   natural: ~0.1.28
-//   msgpack: ~0.2.4
+//   msgpack: ~1.0.2
 //
 // Configuration:
 //   HUBOT_QUOTE_CACHE_SIZE=N - Cache the last N messages for each user for potential remembrance (default 25).


### PR DESCRIPTION
Older versions depended on outdated nan, which won't build on current
Node.js distributions due to a function signature change on
node::Encode.

Fixes #4.

See: https://github.com/nodejs/nan/pull/273
